### PR TITLE
chore(version_control): clean README, rake tasks, git templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Description
+A few sentences describing the overall goals of the pull request's commits.
+
+## Migrations
+YES | NO
+
+## Todos
+- [ ] Tests
+- [ ] Documentation
+
+## Impacted Areas in Application
+List general components of the application that this PR will affect:
+
+*

--- a/.github/commit.template
+++ b/.github/commit.template
@@ -1,0 +1,30 @@
+# type(<scope>): <subject>
+
+# <body>
+
+# <footer>
+
+# type should be one of the following:
+# - feat (new feature)
+# - fix (bug fix)
+# - docs (changes to documentation)
+# - style (formatting, missing semi colons, etc; no code change)
+# - refactor (refactoring production code)
+# - test (adding missing tests, refactoring tests; no production code change)
+# - chore (updating grunt tasks etc; no production code change)
+
+# scope specifies place of the commit change e.g. (admin) or (registration)
+
+# subject should use imperative tone: “change” not “changed” nor “changes”
+# - don't capitalize first letter
+# - no dot (.) at the end
+
+# body should go into detail about changes made
+# - uses imperative, present tense: “change” not “changed” nor “changes”
+# - bullet point or paragraph form are both acceptable
+
+# footer should contain any issue tracking info or actions
+# - e.g. close #123,  close #245, close #992
+
+# For a full example of how to write a good commit message, check out
+# http://karma-runner.github.io/0.8/dev/git-commit-msg.html

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-chiscore-two
+chiscore
 ============
 
-Scoring app for Chiditarod 2013 (and possibly beyond)
-
+## Installation
 You need redis.
 
 `brew install redis` and follow those instructions
@@ -16,27 +15,49 @@ You need node.js for compilation and running of JavaScript specs
 `brew install node` if you don't has it,
 then `npm install -g grunt-cli` -- the grunt-cli may require sudo.
 
-Then, from the root `chiscore-two` directory, `npm install`
+Then, from the root `chiscore` directory, `npm install`
 
-## Server Stuff
-Start the server:
-    `rackup` (or `unicorn` if you're into that)
+## Setup and Server
+Navigate to the  root of the `chiscore` directory:
 
-Run the ruby unit test suite:
-    `rake`
+`cd chiscore`
 
-## Client Stuff
-Run the JavaScript spec suite:
-    `grunt spec`
+Run configuration tasks:
+
+`rake project_setup` (from application root)
+
+Start a local server:
+
+`unicorn` (or `rackup` if you're into that)
+
+Start the Redis server:
+
+`redis-server` (in a new tab or window)
+
+Run test suite:
+
+`rake spec_all` (runs ruby and js suites)
+
+## Other Stuff
+Run the Ruby spec suite only:
+
+`rake spec`
+
+Run the JavaScript spec suite only:
+
+`grunt spec`
 
 Compile coffee and EJS templates:
-    `grunt build`
+
+`grunt build`
 
 Watch and compile coffee and EJS templates:
-    `grunt watch`
+
+`grunt watch`
 
 Remove compiled JS targets:
-    `grunt clean`
+
+`grunt clean`
 
 Logging in: dev environment
 - use test-checkpoint / secret

--- a/Rakefile
+++ b/Rakefile
@@ -3,13 +3,41 @@ $: << File.join(File.dirname(__FILE__), "lib")
 require 'rspec/core/rake_task'
 require 'securerandom'
 
-task :default => [:spec]
+task :default => [:spec_all]
 
-desc "Runs the ruby unit test suite"
-task(:spec) { RSpec::Core::RakeTask.new { |t| t.verbose = false }}
+desc "initial project setup"
+task :project_setup do
+  Rake::Task["gen_secrets"].invoke
+  Rake::Task["commit_template"].invoke
+  puts "\e[32mSuccess!\e[0m"
+end
 
-desc "generate the secret key"
+desc "run all tests"
+task(:spec_all) do
+  sh "grunt spec"
+  Rake::Task["spec"].invoke
+end
+
+desc "run ruby test suite"
+task(:spec) do
+  RSpec::Core::RakeTask.new { |t| t.verbose = false }
+end
+
+desc "generates secret keys"
 task :gen_secrets do
-  File.open("./config/secret_key", "w+") { |file| file << SecureRandom.hex(24) + "\n" }
-  File.open("./config/admin_key", "w+") { |file| file << SecureRandom.hex(24) + "\n" }
+  puts "\e[34mgenerating secret keys...\e[0m"
+
+  File.open("./config/secret_key", "w+") do |file|
+    file << SecureRandom.hex(24) + "\n"
+  end
+
+  File.open("./config/admin_key", "w+") do |file|
+    file << SecureRandom.hex(24) + "\n"
+  end
+end
+
+desc "sets git commit template"
+task :commit_template do
+  puts "\e[34msetting git template...\e[0m"
+  sh "git config commit.template './.github/commit.template'"
 end


### PR DESCRIPTION
Attempts to get everyone on the same page as far as version control strategies and best practices.  Cleans up the README and tries to make initial developer setup easier.
- add PULL_REQUEST_TEMPLATE
- add commit message template
- add rake task for initial project setup
- add rake task that runs entire test suite (js and ruby)
- add rake task for commit template setup
- change header to match repo name
- add instructions for secret key and template setup
- add instructions to run redis server
- add instructions to run entire test suite
- clean code snippets, spacing, and newlines in README
