### PR TITLE
Use correct admin key upon successful admin login

### DIFF
--- a/routers/auth.rb
+++ b/routers/auth.rb
@@ -1,7 +1,5 @@
 module Routers
   class Auth < Router
-    ADMIN_KEY = '3E3928ED-1E96-4011-A31A-4DF24BE003EB'
-
     get("/") { _erb(:"auth/landing") }
     get("/sign_in") { _erb(:"auth/sign_in") }
 
@@ -10,7 +8,7 @@ module Routers
         login = ChiScore::Logins.find_by_username(params[:login])
 
         if login.admin?
-          session['admin'] = ADMIN_KEY
+          session['admin'] = ChiScore::Auth.admin_key
           redirect "/admin"
         else
           session['checkpoint-id'] = login.checkpoints.id


### PR DESCRIPTION
The admin key was hard-coded.  Now it's not, thus the admin user can now successfully login.