### PR TITLE
Convert specs to RSpec 3.4.3 syntax with Transpec

### DIFF
--- a/spec/chiscore/checkins_spec.rb
+++ b/spec/chiscore/checkins_spec.rb
@@ -9,23 +9,23 @@ describe ChiScore::Checkins do
   let(:repo) { ChiScore::Repository }
 
   it "saves the finish-line's check-in and check-out at the same time" do
-    repo.stub(:lock).with("team-id") { -1 }
-    repo.should_receive(:check_in!).with(1001, "team-id")
-    repo.should_receive(:check_out!).with(1001, "team-id")
+    allow(repo).to receive(:lock).with("team-id") { -1 }
+    expect(repo).to receive(:check_in!).with(1001, "team-id")
+    expect(repo).to receive(:check_out!).with(1001, "team-id")
 
     ChiScore::Checkins.checkin(endpoint, team)
   end
 
   it "saves a checkin" do
-    repo.stub(:lock).with("team-id") { -1 }
-    repo.should_receive(:check_in!).with(1000, "team-id")
-    repo.should_not_receive(:check_out!)
+    allow(repo).to receive(:lock).with("team-id") { -1 }
+    expect(repo).to receive(:check_in!).with(1000, "team-id")
+    expect(repo).not_to receive(:check_out!)
 
     ChiScore::Checkins.checkin(checkpoint, team)
   end
 
   it "raises a LockedCheckinAttempt exception if the team has a TTL" do
-    repo.stub(:lock).with("team-id") { 100 }
+    allow(repo).to receive(:lock).with("team-id") { 100 }
 
     expect {
       ChiScore::Checkins.checkin(checkpoint, team)
@@ -33,33 +33,33 @@ describe ChiScore::Checkins do
   end
 
   it "finds all current checkins for a given checkpoint" do
-    repo.should_receive(:active_for).with(1000)
+    expect(repo).to receive(:active_for).with(1000)
 
     ChiScore::Checkins.active(checkpoint)
   end
 
   it "returns a countdown in seconds for all current checkins" do
-    repo.stub(:active_for) { ["teamid1", "teamid2"] }
-    ChiScore::Teams.stub(:find).with("teamid1") { double(:name => "team-one") }
-    ChiScore::Teams.stub(:find).with("teamid2") { double(:name => "team-two") }
-    repo.stub(:time_for).with(1000, "teamid1") { 100 }
-    repo.stub(:time_for).with(1000, "teamid2") { 200 }
+    allow(repo).to receive(:active_for) { ["teamid1", "teamid2"] }
+    allow(ChiScore::Teams).to receive(:find).with("teamid1") { double(:name => "team-one") }
+    allow(ChiScore::Teams).to receive(:find).with("teamid2") { double(:name => "team-two") }
+    allow(repo).to receive(:time_for).with(1000, "teamid1") { 100 }
+    allow(repo).to receive(:time_for).with(1000, "teamid2") { 200 }
 
 
-    result = ChiScore::Checkins.times_for(checkpoint).should =~ [
+    result = expect(ChiScore::Checkins.times_for(checkpoint)).to match_array([
       { :team => { :name => "team-one", :id => "teamid1" }, :time => 100 },
       { :team => { :name => "team-two", :id => "teamid2" }, :time => 200 }
-    ]
+    ])
   end
 
   it "checks out a team if their time left is less than a minute" do
-    repo.stub(:lock).with("team-id") { 59 }
-    repo.should_receive(:check_out!).with(1000, "team-id")
+    allow(repo).to receive(:lock).with("team-id") { 59 }
+    expect(repo).to receive(:check_out!).with(1000, "team-id")
     ChiScore::Checkins.checkout(checkpoint, team, false)
   end
 
   it "raises an early checkout error if team time left is a minute or greater" do
-    repo.stub(:lock).with("team-id") { 60 }
+    allow(repo).to receive(:lock).with("team-id") { 60 }
     expect {
       ChiScore::Checkins.checkout(checkpoint, team, false)
     }.to raise_error ChiScore::Checkins::EarlyCheckout
@@ -67,7 +67,7 @@ describe ChiScore::Checkins do
 
   it "does not raise early checkout error if team time left is a minute or greater and admin" do
     repo.set_strategy(ChiScore::NoopRepositoryStrategy)
-    repo.stub(:lock).with("team-id") { 60 }
+    allow(repo).to receive(:lock).with("team-id") { 60 }
 
     expect {
       ChiScore::Checkins.checkout(checkpoint, team, true)
@@ -75,7 +75,7 @@ describe ChiScore::Checkins do
   end
 
   it "delegates destruction to the repository if admin" do
-    repo.stub(:destroy_checkin!) { "destroyed" }
+    allow(repo).to receive(:destroy_checkin!) { "destroyed" }
     expect(ChiScore::Checkins.destroy_checkin(checkpoint, team, true)).to eq("destroyed")
   end
 
@@ -96,32 +96,32 @@ describe ChiScore::Checkins do
     ChiScore::Teams.save(team2)
     ChiScore::Teams.save(team3)
 
-    checkpoint.stub(:all_teams) { [team1, team2, team3] }
+    allow(checkpoint).to receive(:all_teams) { [team1, team2, team3] }
 
-    repo.stub(:checkins_for) do
+    allow(repo).to receive(:checkins_for) do
       { team1.id => in_time, team2.id => in_time }
     end
 
-    ChiScore::Checkins.remaining_teams(checkpoint).should == [team3]
+    expect(ChiScore::Checkins.remaining_teams(checkpoint)).to eq([team3])
   end
 
   it "gets all checkin / checkout times for a checkpoint" do
     out_time, in_time = Time.now, Time.now - 25 * 60
 
-    ChiScore::Teams.stub(:find).with("teamid1") { double(:name => "team-one") }
-    ChiScore::Teams.stub(:find).with("teamid2") { double(:name => "team-two") }
-    ChiScore::Teams.stub(:find).with("teamid3") { double(:name => "team-three") }
+    allow(ChiScore::Teams).to receive(:find).with("teamid1") { double(:name => "team-one") }
+    allow(ChiScore::Teams).to receive(:find).with("teamid2") { double(:name => "team-two") }
+    allow(ChiScore::Teams).to receive(:find).with("teamid3") { double(:name => "team-three") }
 
-    repo.stub(:checkins_for) do
+    allow(repo).to receive(:checkins_for) do
       {"teamid1" => in_time, "teamid2" => in_time, "teamid3" => in_time}
     end
 
-    repo.stub(:checkouts_for) {{ "teamid1" => out_time, "teamid2" => out_time }}
+    allow(repo).to receive(:checkouts_for) {{ "teamid1" => out_time, "teamid2" => out_time }}
 
-    ChiScore::Checkins.all_for(checkpoint).should == [
+    expect(ChiScore::Checkins.all_for(checkpoint)).to eq([
       { :team => { :name => "team-one", :id => "teamid1"}, :times => [in_time, out_time]},
       { :team => { :name => "team-two", :id => "teamid2"}, :times => [in_time, out_time]},
       { :team => { :name => "team-three", :id => "teamid3"}, :times => [in_time, nil]}
-    ]
+    ])
   end
 end

--- a/spec/chiscore/checkpoints_spec.rb
+++ b/spec/chiscore/checkpoints_spec.rb
@@ -5,15 +5,15 @@ describe ChiScore::Checkpoints do
 
   describe ChiScore::Checkpoint do
     it "has an id" do
-      checkpoint.id.should == 1
+      expect(checkpoint.id).to eq(1)
     end
 
     it "has a name" do
-      checkpoint.name.should == "The Bottom Lounge"
+      expect(checkpoint.name).to eq("The Bottom Lounge")
     end
 
     it "has a role" do
-      checkpoint.role.should == "default"
+      expect(checkpoint.role).to eq("default")
     end
 
     it "has a list of all teams" do
@@ -29,12 +29,12 @@ describe ChiScore::Checkpoints do
       ChiScore::Teams.save(team1)
       ChiScore::Teams.save(team2)
 
-      checkpoint.all_teams.should == [team1]
+      expect(checkpoint.all_teams).to eq([team1])
     end
   end
 
   it "saves a checkpoint" do
     ChiScore::Checkpoints.save(checkpoint)
-    ChiScore::Checkpoints.find(checkpoint.id).should == checkpoint
+    expect(ChiScore::Checkpoints.find(checkpoint.id)).to eq(checkpoint)
   end
 end

--- a/spec/chiscore/logins_spec.rb
+++ b/spec/chiscore/logins_spec.rb
@@ -9,27 +9,27 @@ describe ChiScore::Login do
   }
 
   it "has a login account with a username and password" do
-    checkpoint_login.id.should == 'login_1'
-    checkpoint_login.username.should == 'username'
-    checkpoint_login.password.should_not == 'password'
+    expect(checkpoint_login.id).to eq('login_1')
+    expect(checkpoint_login.username).to eq('username')
+    expect(checkpoint_login.password).not_to eq('password')
   end
 
   it "is authorized if the password matches a login" do
-    checkpoint_login.auth?('password').should == true
-    checkpoint_login.auth?('derp').should == false
+    expect(checkpoint_login.auth?('password')).to eq(true)
+    expect(checkpoint_login.auth?('derp')).to eq(false)
   end
 
   it "is an admin account if access is 0" do
-    admin_login.admin?.should == true
-    checkpoint_login.admin?.should == false
+    expect(admin_login.admin?).to eq(true)
+    expect(checkpoint_login.admin?).to eq(false)
   end
 
   it "has one associated checkpoint if access isn't 0" do
-    checkpoint_login.checkpoints.id.should == 1
+    expect(checkpoint_login.checkpoints.id).to eq(1)
   end
 
   it "has all checkpoints if admin" do
-    admin_login.checkpoints.count.should > 1
+    expect(admin_login.checkpoints.count).to be > 1
   end
 
 end
@@ -40,7 +40,7 @@ describe ChiScore::Logins do
   }
 
   it "finds a login by its username" do
-    ChiScore::Logins.find_by_username("roots").username.should == "roots"
+    expect(ChiScore::Logins.find_by_username("roots").username).to eq("roots")
   end
 
 end

--- a/spec/chiscore/repository/redis_strategy_spec.rb
+++ b/spec/chiscore/repository/redis_strategy_spec.rb
@@ -7,60 +7,60 @@ describe ChiScore::RedisStrategy do
 
   before {
     subject.redis.select(14)
-    Time.stub(:now) { now }
+    allow(Time).to receive(:now) { now }
   }
 
   after { subject.redis.flushdb }
 
   it "sets an active team for a checkpoint" do
     subject.check_in!("checkpoint-id", "team-id")
-    subject.active_for("checkpoint-id").should == ["team-id"]
+    expect(subject.active_for("checkpoint-id")).to eq(["team-id"])
   end
 
   it "saves the race's start time" do
     current_time = Time.now
-    Time.stub(:now) { current_time }
+    allow(Time).to receive(:now) { current_time }
     subject.save_race_start
-    subject.fetch_race_start.should == current_time.to_i.to_s
+    expect(subject.fetch_race_start).to eq(current_time.to_i.to_s)
 
-    Time.stub(:now) { Time.now.to_i + 1000 }
+    allow(Time).to receive(:now) { Time.now.to_i + 1000 }
     subject.save_race_start
-    subject.fetch_race_start.should == current_time.to_i.to_s
+    expect(subject.fetch_race_start).to eq(current_time.to_i.to_s)
   end
 
   it "removes an active team from a checkpoint on checkout" do
     subject.check_in!("checkpoint-id", "team-id")
     subject.check_out!("checkpoint-id", "team-id")
-    subject.active_for("checkpoint-id").should be_empty
+    expect(subject.active_for("checkpoint-id")).to be_empty
   end
 
   it "gets a time for a given record" do
     subject.check_in!("checkpoint-id", "team-id")
-    subject.time_for("checkpoint-id", "team-id").should be > (25*60)-5
+    expect(subject.time_for("checkpoint-id", "team-id")).to be > (25*60)-5
   end
 
   it "returns -1 for a time that doesn't exist" do
-    subject.time_for("checkpoint-id", "team-id").should == -2
+    expect(subject.time_for("checkpoint-id", "team-id")).to eq(-2)
   end
 
   it "gets checkins for checkpoints" do
     subject.check_in!("checkpoint-id", "team-id1")
     subject.check_in!("checkpoint-id", "team-id2")
 
-    subject.checkins_for("checkpoint-id").should == {
+    expect(subject.checkins_for("checkpoint-id")).to eq({
       "team-id1" => now.to_i,
       "team-id2" => now.to_i
-    }
+    })
   end
 
   it "gets checkouts for checkpoints" do
     subject.check_out!("checkpoint-id", "team-id1")
     subject.check_out!("checkpoint-id", "team-id2")
 
-    subject.checkouts_for("checkpoint-id").should == {
+    expect(subject.checkouts_for("checkpoint-id")).to eq({
       "team-id1" => now.to_i,
       "team-id2" => now.to_i
-    }
+    })
   end
 
   it "gets the time for the checkout for a given record" do

--- a/spec/chiscore/repository_spec.rb
+++ b/spec/chiscore/repository_spec.rb
@@ -6,7 +6,7 @@ describe ChiScore::Repository do
 
   it "sets/gets a strategy" do
     ChiScore::Repository.set_strategy(strategy)
-    ChiScore::Repository.strategy.should == strategy
+    expect(ChiScore::Repository.strategy).to eq(strategy)
   end
 
   [
@@ -21,7 +21,7 @@ describe ChiScore::Repository do
   ].each do |method_name|
     it "delegates #{method_name} to strategy" do
       ChiScore::Repository.set_strategy(strategy)
-      strategy.should_receive(method_name)
+      expect(strategy).to receive(method_name)
 
       ChiScore::Repository.send(method_name)
     end

--- a/spec/chiscore/routes_spec.rb
+++ b/spec/chiscore/routes_spec.rb
@@ -7,34 +7,34 @@ describe ChiScore::Routes do
 
   describe ChiScore::Route do
     it "has a route ID" do
-      route.id.should == 1
+      expect(route.id).to eq(1)
     end
 
     it "has a list of checkpoint IDs" do
-      route.checkpoint_ids.should == [1, 2, 3]
+      expect(route.checkpoint_ids).to eq([1, 2, 3])
     end
 
     it "truncates the checkpoint IDs if they're nil" do
-      ChiScore::Route.new(1, [1, 2, nil]).checkpoint_ids.should == [1,2]
+      expect(ChiScore::Route.new(1, [1, 2, nil]).checkpoint_ids).to eq([1,2])
     end
 
     it "has a list of checkpoints" do
       checkpoint1, checkpoint2, checkpoint3 = [1, 2, 3].map { |num| ChiScore::Checkpoint.new(num, num.to_s)}
-      ChiScore::Checkpoints.stub(:find).with(1) { checkpoint1 }
-      ChiScore::Checkpoints.stub(:find).with(2) { checkpoint2 }
-      ChiScore::Checkpoints.stub(:find).with(3) { checkpoint3 }
-      route.checkpoints.should == [checkpoint1, checkpoint2, checkpoint3]
+      allow(ChiScore::Checkpoints).to receive(:find).with(1) { checkpoint1 }
+      allow(ChiScore::Checkpoints).to receive(:find).with(2) { checkpoint2 }
+      allow(ChiScore::Checkpoints).to receive(:find).with(3) { checkpoint3 }
+      expect(route.checkpoints).to eq([checkpoint1, checkpoint2, checkpoint3])
     end
 
     it "has teams" do
       team = double
-      ChiScore::Teams.stub(:for_route).with(route) { [ team ] }
-      route.teams.should == [team]
+      allow(ChiScore::Teams).to receive(:for_route).with(route) { [ team ] }
+      expect(route.teams).to eq([team])
     end
   end
 
   it "saves a route" do
     ChiScore::Routes.save(route)
-    ChiScore::Routes.find(route.id).should == route
+    expect(ChiScore::Routes.find(route.id)).to eq(route)
   end
 end

--- a/spec/chiscore/teams_spec.rb
+++ b/spec/chiscore/teams_spec.rb
@@ -8,20 +8,20 @@ describe ChiScore::Teams do
 
   describe ChiScore::Team do
     it "has an id" do
-      team.id.should == "forty-two"
+      expect(team.id).to eq("forty-two")
     end
 
     it "has a name" do
-      team.name.should == "Dynasty"
+      expect(team.name).to eq("Dynasty")
     end
 
     it "has a route" do
-      team.route.should == 5
+      expect(team.route).to eq(5)
     end
 
     it "initalizes checkins/checkouts to empty list" do
-      team.checkins.should == []
-      team.checkouts.should == []
+      expect(team.checkins).to eq([])
+      expect(team.checkouts).to eq([])
     end
 
     describe "#<=>" do
@@ -50,12 +50,12 @@ describe ChiScore::Teams do
 
     it "gets teams with a given route" do
       route = double(:id => 5)
-      ChiScore::Teams.for_route(route).should == [team]
+      expect(ChiScore::Teams.for_route(route)).to eq([team])
     end
   end
 
   it "stores a team" do
     ChiScore::Teams.save(team)
-    ChiScore::Teams.find(team.id).should == team
+    expect(ChiScore::Teams.find(team.id)).to eq(team)
   end
 end

--- a/spec/routers/admin_spec.rb
+++ b/spec/routers/admin_spec.rb
@@ -15,16 +15,16 @@ describe Routers::Admin do
   end
 
   it "if admin, saves race start time and redirects after request" do
-    ChiScore::Repository.should_receive(:save_race_start)
+    expect(ChiScore::Repository).to receive(:save_race_start)
     expect(ChiScore::Auth).to receive(:admin_key) { admin_key }
     browser.get "/start-race", {}, 'rack.session' => { "admin" => admin_key }
-    browser.last_response.status.should == 302
+    expect(browser.last_response.status).to eq(302)
   end
 
   it "if not admin, does not save race start time and redirects after request" do
-    ChiScore::Repository.should_not_receive(:save_race_start)
+    expect(ChiScore::Repository).not_to receive(:save_race_start)
     expect(ChiScore::Auth).to receive(:admin_key) { admin_key }
     browser.get "/", {}, 'rack.session' => { "admin" => "" }
-    browser.last_response.status.should == 302
+    expect(browser.last_response.status).to eq(302)
   end
 end

--- a/spec/routers/checkpoint_spec.rb
+++ b/spec/routers/checkpoint_spec.rb
@@ -20,37 +20,37 @@ describe Routers::Checkpoint do
 
   it "doesn't redirect an admin" do
     browser.get "/admin", {}, 'rack.session' => { "admin" => admin_key }
-    browser.last_response.status.should_not eq 302
+    expect(browser.last_response.status).not_to eq 302
   end
 
   it "doesn't redirect a checkpoint login user for 'all'" do
-    ChiScore::Checkpoints.stub(:find) {  checkpoint }
-    ChiScore::Checkins.stub(:all_for) { [] }
+    allow(ChiScore::Checkpoints).to receive(:find) {  checkpoint }
+    allow(ChiScore::Checkins).to receive(:all_for) { [] }
 
     browser.get "/all", {}, 'rack.session' => { "checkpoint-id" => 2 }
-    browser.last_response.status.should_not eq 302
+    expect(browser.last_response.status).not_to eq 302
   end
 
   it "doesn't redirect a checkpoint login user for root" do
-    ChiScore::Checkpoints.stub(:find) {  checkpoint }
+    allow(ChiScore::Checkpoints).to receive(:find) {  checkpoint }
     browser.get "/", {}, 'rack.session' => { "checkpoint-id" => 2 }
-    browser.last_response.status.should_not eq 302
+    expect(browser.last_response.status).not_to eq 302
   end
 
   it "redirects non-logged in user to auth from root" do
     browser.get "/"
-    browser.last_response.status.should eq 302
+    expect(browser.last_response.status).to eq 302
   end
 
   it "redirects a user if not admin" do
-    ChiScore::Checkins.stub(:all_for) { [] }
+    allow(ChiScore::Checkins).to receive(:all_for) { [] }
     browser.get "/all"
-    browser.last_response.status.should eq 302
+    expect(browser.last_response.status).to eq 302
   end
 
   it "redirects a user to admin page if admin" do
     browser.get "/all", {}, 'rack.session' => { "admin" => admin_key }
-    browser.last_response.status.should eq 302
+    expect(browser.last_response.status).to eq 302
   end
 
 end

--- a/spec/routers/helpers/leaderboard_helper_spec.rb
+++ b/spec/routers/helpers/leaderboard_helper_spec.rb
@@ -13,13 +13,13 @@ describe LeaderboardHelper do
       let(:status) { LeaderboardHelper::CheckinStatus.new(checkpoint, team, false) }
 
       before(:each) do
-        status.stub(:update_checkin_count)
-        ChiScore::Checkins.stub(:checkout_for).and_return(1)
-        ChiScore::Checkins.stub(:time_for).and_return(1)
+        allow(status).to receive(:update_checkin_count)
+        allow(ChiScore::Checkins).to receive(:checkout_for).and_return(1)
+        allow(ChiScore::Checkins).to receive(:time_for).and_return(1)
       end
 
       it "returns blank if checkin has not happened" do
-        status.stub(:find_time).and_return(0)
+        allow(status).to receive(:find_time).and_return(0)
         expect(status.evaluate).to eq("--")
       end
 
@@ -33,18 +33,18 @@ describe LeaderboardHelper do
       let(:status) { LeaderboardHelper::CheckinStatus.new(checkpoint, team, true) }
 
       before(:each) do
-        status.stub(:update_checkin_count)
-        ChiScore::Checkins.stub(:checkout_for).and_return(1)
-        ChiScore::Checkins.stub(:time_for).and_return(1)
+        allow(status).to receive(:update_checkin_count)
+        allow(ChiScore::Checkins).to receive(:checkout_for).and_return(1)
+        allow(ChiScore::Checkins).to receive(:time_for).and_return(1)
       end
 
       it "returns blank if checkin has not happened" do
-        status.stub(:find_time).and_return(0)
+        allow(status).to receive(:find_time).and_return(0)
         expect(status.evaluate).to eq("--")
       end
 
       it "returns checked_in_status if currently checked in" do
-        status.stub(:checked_out?).and_return(false)
+        allow(status).to receive(:checked_out?).and_return(false)
         expect(status.evaluate).to eq(status.html_output("green", checkin_time))
       end
 

--- a/spec/routers/public_spec.rb
+++ b/spec/routers/public_spec.rb
@@ -8,17 +8,17 @@ describe Routers::Public do
 
   let(:app) { Routers::Public }
 
-  before(:each) { app.any_instance.stub(:update_scores) }
+  before(:each) { allow_any_instance_of(app).to receive(:update_scores) }
 
   it "redirects if admin" do
-    app.any_instance.stub(:admin?) { true }
+    allow_any_instance_of(app).to receive(:admin?) { true }
     get "/"
     expect(last_response).to be_redirect
     expect(last_response.location).to include("/admin")
   end
 
   it "redirects if route doesn't exist" do
-    ChiScore::Routes.stub(:find).and_raise(KeyError)
+    allow(ChiScore::Routes).to receive(:find).and_raise(KeyError)
     get "/error"
     expect(last_response).to be_redirect
     expect(last_response.location).to eq("http://example.org/public")


### PR DESCRIPTION
This conversion is done by Transpec 3.3.0 with the following command:
    transpec

* 56 conversions
    from: obj.should
      to: expect(obj).to

* 52 conversions
    from: obj.stub(:message)
      to: allow(obj).to receive(:message)

* 50 conversions
    from: == expected
      to: eq(expected)

* 14 conversions
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

* 5 conversions
    from: Klass.any_instance.stub(:message)
      to: allow_any_instance_of(Klass).to receive(:message)

* 4 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 2 conversions
    from: obj.should_not_receive(:message)
      to: expect(obj).not_to receive(:message)

* 1 conversion
    from: =~ [1, 2]
      to: match_array([1, 2])

* 1 conversion
    from: > expected
      to: be > expected

* 1 conversion
    from: obj.stub(:message => value)
      to: allow(obj).to receive_messages(:message => value)

For more details: https://github.com/yujinakayama/transpec#supported-conversions