### PR TITLE
increase destroy checkout limit for checkpoints

### DIFF
--- a/lib/chiscore/checkins.rb
+++ b/lib/chiscore/checkins.rb
@@ -8,6 +8,9 @@ module ChiScore
     EarlyCheckout        = Class.new(StandardError)
     IllegalDestroy       = Class.new(StandardError)
 
+    CHECKIN_LENGTH = 1500 # 25 minutes
+    DESTROY_CHECKIN_TIMEFRAME = CHECKIN_LENGTH - 300 # 5 minutes
+
     class << self
       def checkin(checkpoint, team, *args)
         raise LockedCheckinAttempt if locked?(team)
@@ -82,7 +85,7 @@ module ChiScore
       end
 
       def destroy_checkin(checkpoint, team, admin)
-        if Repository.lock(team.id) <= 1300 && !admin
+        if Repository.lock(team.id) <= DESTROY_CHECKIN_TIMEFRAME && !admin
           raise IllegalDestroy
         end
 

--- a/spec/chiscore/checkins_spec.rb
+++ b/spec/chiscore/checkins_spec.rb
@@ -80,16 +80,16 @@ describe ChiScore::Checkins do
     expect(ChiScore::Checkins.destroy_checkin(checkpoint, team, true)).to eq("destroyed")
   end
 
-  it "returns an Illegal Destroy error if not admin" do
-    allow(repo).to receive(:lock).with("team-id") { 100 }
+  it "returns an Illegal Destroy error if not admin, and past expiration" do
+    allow(repo).to receive(:lock).with("team-id") { 1199 }
 
     expect{
       ChiScore::Checkins.destroy_checkin(checkpoint, team, false)
     }.to raise_error ChiScore::Checkins::IllegalDestroy
   end
 
-  it "does not raise error if there are fewer than 4 minutes expired from check-in time" do
-    allow(repo).to receive(:lock).with("team-id") { 1301 }
+  it "does not raise error if fewer than 5min expired" do
+    allow(repo).to receive(:lock).with("team-id") { 1201 }
     allow(repo).to receive(:destroy_checkin!) { "destroyed" }
 
     expect(


### PR DESCRIPTION
Raise limit from 4 minutes to 5 minutes

* You can only destroy a checkin if it's within 5 minutes.
* Teams can't check into another checkpoint for 25 minutes after checking in, unless unlocked by an admin.
* You can only destroy checkins for your checkpoint.

This means the only people who can destroy checkins are the checkpoints that checked them in, less than 5 minutes ago.