### PR TITLE
use time scoped to checkpoint for early checkout errors

### DIFF
--- a/lib/chiscore/checkins.rb
+++ b/lib/chiscore/checkins.rb
@@ -42,7 +42,8 @@ module ChiScore
       end
 
       def checkout(checkpoint, team, admin)
-        raise EarlyCheckout if !admin && early?(team)
+        is_early = Repository.time_for(checkpoint.id, team.id) >= 60
+        raise EarlyCheckout if !admin && is_early
         Repository.check_out!(checkpoint.id, team.id)
       end
 


### PR DESCRIPTION
This provides a fix for the issue raised in #13 by scoping potential early checkout errors and checks to the requested checkpoint.

### Previous behavior:

1. Team A checks in to Checkpoint Z. They leave and head to Checkpoint Y when their time is up, but the operator for Z doesn't check them out.
2. Team A checks into Checkpoint Y
3. Checkpoint Z attempts to checkout the expired checkin and receives an error

(note that the _TIME_ display for Z is correct, just they receive an invalid error on a checkout attempt)

### New behavior:

1. See steps 1 and 2 above
2. Checkpoint Z is able to check out the expired checkin without issue.

